### PR TITLE
Fixed spelling error from 'resoures_layer' to 'resources_layer'

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Let's walk through what happens when a FITS file is uploaded to the source bucke
 ### How to Create a layer for the lambda function
 
 ```
-$ mkdir resoures_layer
+$ mkdir resources_layer
 $ mkdir python
 $ pip install aws_cdk.aws_lambda aws_cdk.aws_s3
 $ pip install astropy --target python


### PR DESCRIPTION
*Issue NA*

*Description of changes:*
Updated readme to fix correction in creating astropy layer.
Fixed spelling error from 'resoures_layer' to 'resources_layer' in README.md


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
