### PR TITLE
updated path resources_layer in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Let's walk through what happens when a FITS file is uploaded to the source bucke
 ### How to Create a layer for the lambda function
 
 ```
-$ mkdir resoures_layer
+$ mkdir resources_layer
 $ mkdir python
 $ pip install aws_cdk.aws_lambda aws_cdk.aws_s3
 $ pip install astropy --target python


### PR DESCRIPTION
Tiny correction to README.md (name of folder "resources_layer" was misspelled)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
